### PR TITLE
multiple changes

### DIFF
--- a/mw.asl
+++ b/mw.asl
@@ -1,9 +1,12 @@
- state("iw3sp")
-    {
-  	int loading1 : 0x10B1100;
-	string200 map : 0x6C3140;
-	int boi : 0xCDE4C8;
-    }
+//Call of Duty 4: Modern Warfare Autosplitter + Load Remover
+//original script by KunoDemetries
+//cleaned up and some extra features by rythin
+
+state("iw3sp") {
+  	int loading1:	0x10B1100;
+	string20 map:	0x6C3140;
+	int boi:	0xCDE4C8;
+}
 
 startup {
         settings.Add("act0", true, "Prologue");
@@ -12,17 +15,17 @@ startup {
         settings.Add("act3", true, "Act 3");
 
         vars.missions1 = new Dictionary<string,string> { 
+		{"killhouse", "F.N.G."},
 		{"cargoship", "Crew Expendable"}, 
 		{"coup", "The Coup"},
         };
-        vars.missions1A = new List<string>();
+		
         foreach (var Tag in vars.missions1) {
-        settings.Add(Tag.Key, true, Tag.Value, "act0");
-        vars.missions1A.Add(Tag.Key); 
+		settings.Add(Tag.Key, true, Tag.Value, "act0");
         };
 
         vars.missions2 = new Dictionary<string,string> { 
-		{"blackout", "blackout"},
+		{"blackout", "Blackout"},
 		{"armada", "Charlie Dont Surf"},
 		{"bog_a", "The Bog"},
 		{"hunted", "Hunted"},	
@@ -32,10 +35,9 @@ startup {
 		{"aftermath", "Aftermath"},
         };
 
-        vars.missions2A = new List<string>();
         foreach (var Tag in vars.missions2) {
-        settings.Add(Tag.Key, true, Tag.Value, "act1");
-        vars.missions2A.Add(Tag.Key); };
+		settings.Add(Tag.Key, true, Tag.Value, "act1");
+        };
 
         vars.missions3 = new Dictionary<string,string> { 
 		{"village_assault", "Safe House"},
@@ -44,70 +46,84 @@ startup {
 		{"village_defend", "Heat"},
 		{"ambush", "The Sins of the Father"},
         };
-        vars.missions3A = new List<string>();
+		
         foreach (var Tag in vars.missions3) {
-        settings.Add(Tag.Key, true, Tag.Value, "act2");
-        vars.missions3A.Add(Tag.Key); };
+		settings.Add(Tag.Key, true, Tag.Value, "act2");
+        };
         
         vars.missions4 = new Dictionary<string,string> { 
 		{"icbm", "Ultimatum"},
 		{"launchfacility_a", "All In"},
 		{"launchfacility_b", "No Fighting in The War Room"},
 		{"jeepride", "Game Over"},
-		};  
+	};
         
-        vars.missions4A = new List<string>();
         foreach (var Tag in vars.missions4) {
-        settings.Add(Tag.Key, true, Tag.Value, "act3");
-        vars.missions4A.Add(Tag.Key); };
+		settings.Add(Tag.Key, true, Tag.Value, "act3");
+        };
 	    
 	    refreshRate = 30;
     }
 
-init
-    {
-    vars.doneMaps = new List<string>(); 
-    }
+init {
+	vars.doneMaps = new List<string>(); 
+	vars.coupOffset = false;
+	vars.currentTime = new TimeSpan(0, 0, 0);	//TimeSpan object used to add a timer offset after The Coup
+}
 
-split
-    {
-    string currentMap = current.map;
+update {
+	vars.currentTime = timer.CurrentTime.GameTime;	//keep the variable updated with the current time on the timer
+}
 
-    if ((currentMap != old.map)) {
-        if (!vars.doneMaps.Contains(current.map)) {
-            if (settings[currentMap.Trim()]) {
-                if (vars.missions1A.Contains(currentMap) ||
-                vars.missions2A.Contains(currentMap) ||
-                vars.missions3A.Contains(currentMap) ||
-                vars.missions4A.Contains(currentMap)) {
-            vars.doneMaps.Add(current.map);
-            return true;
-            }
-            else {
-            return false;
-            }
-        }
-        }
+start {
+	//changed start condition to happen only after loading in rather than any time in the load
+	if (current.map == "killhouse" && current.loading1 != 0 && old.loading1 == 0) {
+		vars.doneMaps.Clear();		//clear the doneMaps list
+		vars.coupOffset = false;	//set offset to false just in case it somehow stays on
+		return true;				//start the timer
     }
-    return ((current.map == "jeepride") && (current.boi == 139512));
-    }   
+}
 
-start
-    {
-	if ((current.map == "killhouse") && (current.loading1 == 0)) {
-    vars.doneMaps.Clear();
-	vars.doneMaps.Add(current.map);
-    return true;
-    }
-    }
+split {
 
+	if (current.map != old.map) {					//on map change
+		if (old.map == "coup") {				//if the last map was The Coup
+			vars.currentTime = timer.CurrentTime.GameTime;	//set a variable to the value of current time
+			vars.coupOffset = true;				//add 4:44 to the timer
+			if (settings["coup"]) {				//if the split for The Coup is enabled
+				vars.doneMaps.Add(old.map);		//add the last map to done splits list
+				return true;				//split
+			}
+		}
+			
+		else {						//if map is NOT The Coup
+			if (settings[old.map]) {		//if setting for last map is enabled
+				vars.doneMaps.Add(old.map);	//add the last map to done splits list
+				return true;			//split
+			}
+		}
+		
+	}
+
+	//this is kuno's code idk what it does but i assume its the final split
+	//would explain the lack of setting for this one
+	if (current.map == "jeepride" && current.boi == 139512) {
+		return true;
+	}
+}   
  
- reset
-    {
-    return ((current.map == "ui") && (old.map != "ui")) && (old.map != "coup");
-    }
+reset {
+	//kuno's condition, seems sketchy but whatever i dont run this game if it works for yall thats good lol
+	return (current.map != old.map && current.map == "ui" && old.map != "coup");
+}
 
-  isLoading
-    {
-    return (current.loading1 == 0) || (current.map == "coup");
-    }
+gameTime {
+	if (vars.coupOffset == true) {					//when offset gets set to true
+		vars.coupOffset = false;				//set it back to false
+		return vars.currentTime.Add(new TimeSpan (0, 4, 44));	//set the timer to current timer time + 284s (4m44s)
+	}
+}
+
+isLoading {
+	return (current.loading1 == 0) || (current.map == "coup");
+}


### PR DESCRIPTION
- reformatted the code to make it readable
- removed unnecessary split lists
- made map split settings indicate the level that's being completed, rather than the one being entered
- rewrote the split function entirely, to hopefully make it more readable and ready for the new coup offset
- added a timer offset for the coup, adding 4m44s after leaving the level (Klooger said that should be the time being added)
- changed start condition to start after the load is finished, rather than in any load 

note: script was partially tested by Klooger and appears to work fine